### PR TITLE
chore: add frb exports to enum types

### DIFF
--- a/src/api/send_transaction.rs
+++ b/src/api/send_transaction.rs
@@ -61,7 +61,6 @@ pub struct SendTransactionEvent {
     pub details: String,
 }
 
-#[frb]
 #[derive(Error, Debug)]
 pub enum TransactionError {
     #[error("Invalid Recipient Address: {0}")]


### PR DESCRIPTION
Some of types, which are part of enum, did not have `#[frb]` attribute.
It seems, that it did not change the generated *.dart files, though.

Those structs where already correctly generated in Dart without the `#[frb]`.